### PR TITLE
fix: loading state if location permission not granted

### DIFF
--- a/src/components/product/index.js
+++ b/src/components/product/index.js
@@ -98,6 +98,10 @@ const Product = (props) => {
       setDrivingDistance(distance);
       setLoading(false);
     }
+
+    if (!userLocation) {
+      setLoading(false)
+    }
   }, [userLocation, productData]);
 
   const addToCart = async (item) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The modifications I've implemented ensure that the product loads regardless of whether location permission is provided.

## Motivation and Context

The change is required to solve a significant user experience issue. Without this modification, if a user does not grant location permission, the page would remain in a perpetual loading state, preventing interaction with the product. This could lead to frustration and potentially cause users to abandon the site.

This solve this #189 bug

## How Has This Been Tested?

I have conducted tests under both conditions—when location permission is provided and when it is not—and the code functions correctly in each scenario.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.